### PR TITLE
Updating GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: cargo build
+      - name: Build debug
         run: cargo build
-      - name: cargo build --release
+      - name: Build release
         run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,3 @@ jobs:
       - uses: actions/checkout@v2
       - name: cargo build
         run: cargo build --verbose
-
-  style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: cargo fmt
-        run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: cargo build
-        run: cargo build --verbose
+        run: cargo build
+      - name: cargo build --release
+        run: cargo build --release


### PR DESCRIPTION
While I like `cargo fmt` I don't really think it's so important that it needs to be run for all PRs and merges.

I also want us to build release to ensure it can be built.